### PR TITLE
wrapped PortableText in the .wrapper in basicContent.

### DIFF
--- a/src/components/BasicContent.astro
+++ b/src/components/BasicContent.astro
@@ -3,5 +3,6 @@ import { PortableText } from 'astro-portabletext';
 
 const { content } = Astro.props;
 ---
-
-<PortableText value={content} />
+<div class="wrapper">
+    <PortableText value={content} />
+</div>

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -53,7 +53,7 @@ const { faqs } = Astro.props;
     border: none;
     border-bottom: 1px solid #e0e0e0;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: 1.5rem;
     font-weight: bold;
     transition: border-width 0.3s;
     background: none;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -73,9 +73,11 @@ const { data: nav } = await loadQuery<NavData>({
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
   }
   li {
     list-style: none !important;
+    margin-block: 0 !important;
   }
   li:last-child span {
     display: none;

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -150,6 +150,7 @@ const { data: nav } = await loadQuery<NavData>({
   }
   li {
     list-style: none !important;
+    margin: 0 !important;
   }
   button.nav-toggle {
     border: none;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,7 +35,9 @@ const { title } = Astro.props;
   </head>
   <body>
     <Nav />
-    <slot />
+    <main>
+      <slot />
+    </main>
     <Footer/>
   </body>
 </html>

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -103,9 +103,18 @@ em {
 }
 ul {
   color: var(--dark-gray);
+  margin-left: 1rem;
+}
+ol {
+  margin-left: 1rem;
 }
 li:not(.card) {
   list-style: decimal inside;
+  margin-block: 1rem;
+  font-size: 1.25rem;
+}
+li:not(.card) > ul > li {
+  list-style: inside !important;
 }
 blockquote {
   display: inline-block;


### PR DESCRIPTION
adjusted font-sizes for list and faq.
adjusted nav and footer to not be affected by the list style changes. wrapped the slot in "main"

The blog pages look closer to the intended designs.

I noticed that a lot of the "lists" were being read as p tags because in the CMS we were just typing 1) or 1. and not activating an actual list. 
I changed the ones I saw to lists.

Then I noticed only the side-by-side has an ordered list option in the text editor. A ticket has been made in Trello.